### PR TITLE
Migrated to ASP.NET Core 2.0, ExternalCookie project not included

### DIFF
--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.DynamicLocalizer/Sakura.AspNetCore.DynamicLocalizer.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.DynamicLocalizer/Sakura.AspNetCore.DynamicLocalizer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Sakura.AspNetCore.Localization</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>ASP.NET Core MVC Dynamic Localizer Service</Title>
@@ -9,7 +9,8 @@
     <Company>Iris Sakura</Company>
     <Product>Sakura.AspNetCore.Extensions</Product>
     <Description>This package provide dynamic style localiazation resource accesing ability.</Description>
-    <PackageReleaseNotes>Add xml documentation.</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/sgjsakura/AspNetCore.git</RepositoryUrl>
@@ -18,11 +19,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.6\Sakura.AspNetCore.DynamicLocalizer.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netcoreapp2.0\Sakura.AspNetCore.DynamicLocalizer.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Messages.Abstractions/Sakura.AspNetCore.Messages.Abstractions.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Messages.Abstractions/Sakura.AspNetCore.Messages.Abstractions.csproj
@@ -5,12 +5,13 @@
     <AssemblyTitle>ASP.NET Core Operation Message Abstraction Layer</AssemblyTitle>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Authors>Iris Sakura</Authors>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Sakura.AspNetCore.Messages.Abstractions</AssemblyName>
     <PackageId>Sakura.AspNetCore.Messages.Abstractions</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;Message;Messages</PackageTags>
-    <PackageReleaseNotes>VS2017 Update</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Messages/Sakura.AspNetCore.Messages.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Messages/Sakura.AspNetCore.Messages.csproj
@@ -5,11 +5,12 @@
     <AssemblyTitle>ASP.NET Core Operation Message Core Library</AssemblyTitle>
     <VersionPrefix>1.0.2</VersionPrefix>
     <Authors>Iris Sakura</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Sakura.AspNetCore.Messages</AssemblyName>
     <PackageId>Sakura.AspNetCore.Messages</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;Message;Messages</PackageTags>
-    <PackageReleaseNotes>VS2017 Update</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -25,16 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
 </Project>

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.ActionResultExceptionExtensions/Sakura.AspNetCore.Mvc.ActionResultExceptionExtensions.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.ActionResultExceptionExtensions/Sakura.AspNetCore.Mvc.ActionResultExceptionExtensions.csproj
@@ -4,12 +4,13 @@
     <Description>This library classes and helper methods which can be used to return action results directly during the MVC executing pipeline.</Description>
     <AssemblyTitle>ASP.NET Core ActionResult Extension Library</AssemblyTitle>
     <Authors>Iris Sakura</Authors>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Sakura.AspNetCore.Mvc.ActionResultExceptionExtensions</AssemblyName>
     <PackageId>Sakura.AspNetCore.Mvc.ActionResultExceptionExtensions</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;MVC;MVCCore;Exception</PackageTags>
-    <PackageReleaseNotes>Update to .NET Core 1.1</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -21,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.Messages/Sakura.AspNetCore.Mvc.Messages.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.Messages/Sakura.AspNetCore.Mvc.Messages.csproj
@@ -5,11 +5,12 @@
     <AssemblyTitle>ASP.NET Core MVC Message Extension Library</AssemblyTitle>
     <VersionPrefix>1.0.2</VersionPrefix>
     <Authors>Iris Sakura</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Sakura.AspNetCore.Mvc.Messages</AssemblyName>
     <PackageId>Sakura.AspNetCore.Mvc.Messages</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;MVC;MVCCore;Bootstrap;Message;Messages</PackageTags>
-    <PackageReleaseNotes>Fix HtmlGenerator bugs</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -25,16 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
 </Project>

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.PagedList/Sakura.AspNetCore.Mvc.PagedList.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.PagedList/Sakura.AspNetCore.Mvc.PagedList.csproj
@@ -5,11 +5,12 @@
     <AssemblyTitle>ASP.NET Core MVC Pager</AssemblyTitle>
     <VersionPrefix>2.0.11</VersionPrefix>
     <Authors>Iris Sakura</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Sakura.AspNetCore.Mvc.PagedList</AssemblyName>
     <PackageId>Sakura.AspNetCore.Mvc.PagedList</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;MVC;MVCCore;Paging;Page;Pager;Bootstrap</PackageTags>
-    <PackageReleaseNotes>Add support for much more extended tag helpers used to simplify pager generation.</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -26,17 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
 </Project>

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.TagHelpers/AuthorizeTagHelperBase.cs
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.TagHelpers/AuthorizeTagHelperBase.cs
@@ -1,18 +1,17 @@
-﻿using System.Security.Claims;
-using System.Threading.Tasks;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Threading.Tasks;
 
 namespace Sakura.AspNetCore.Mvc.TagHelpers
 {
-	/// <summary>
-	///     Provide common implementations for both <see cref="AuthorizeTagHelper" /> and
-	///     <see cref="AuthorizeAttributeTagHelper" />.
-	/// </summary>
-	public abstract class AuthorizeTagHelperBase : TagHelper
+    /// <summary>
+    ///     Provide common implementations for both <see cref="AuthorizeTagHelper" /> and
+    ///     <see cref="AuthorizeAttributeTagHelper" />.
+    /// </summary>
+    public abstract class AuthorizeTagHelperBase : TagHelper
 	{
 		/// <summary>
 		///     Initialize a new instance of <see cref="AuthorizeTagHelperBase" />.
@@ -48,9 +47,9 @@ namespace Sakura.AspNetCore.Mvc.TagHelpers
 		///     Get a value that indicates if the current user is authorized.
 		/// </summary>
 		/// <returns>If the current user is authorized, returns <c>true</c>; otherwise, returns <c>false</c>.</returns>
-		protected Task<bool> IsAuthorizedAsync()
+		protected async Task<bool> IsAuthorizedAsync()
 		{
-			return AuthorizationService.AuthorizeAsync(ViewContext.HttpContext.User, Resource, Policy);
+			return (await AuthorizationService.AuthorizeAsync(ViewContext.HttpContext.User, Resource, Policy)).Succeeded;
 		}
 
 		#region Overrides of TagHelper

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.TagHelpers/FlagsEnumModelBinder.cs
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.TagHelpers/FlagsEnumModelBinder.cs
@@ -1,15 +1,14 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.Internal;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Sakura.AspNetCore.Mvc.TagHelpers
 {
-	/// <summary>
-	///     Support binding a flags enum value with multiple flag inputs.
-	/// </summary>
-	public class FlagsEnumModelBinder : IModelBinder
+    /// <summary>
+    ///     Support binding a flags enum value with multiple flag inputs.
+    /// </summary>
+    public class FlagsEnumModelBinder : IModelBinder
 	{
 		/// <summary>Attempts to bind a model.</summary>
 		/// <param name="bindingContext">The <see cref="ModelBindingContext" />.</param>
@@ -30,13 +29,13 @@ namespace Sakura.AspNetCore.Mvc.TagHelpers
 		{
 			// Only accept enum values
 			if (!bindingContext.ModelMetadata.IsFlagsEnum)
-				return TaskCache.CompletedTask;
+				return Task.CompletedTask;
 
 			var provideValue = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
 
 			// Do nothing if there is no actual values
 			if (provideValue == ValueProviderResult.None)
-				return TaskCache.CompletedTask;
+				return Task.CompletedTask;
 
 			// Get the real enum type
 			var enumType = bindingContext.ModelType;
@@ -57,7 +56,7 @@ namespace Sakura.AspNetCore.Mvc.TagHelpers
 			// Result
 			bindingContext.Result = ModelBindingResult.Success(realResult);
 
-			return TaskCache.CompletedTask;
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.TagHelpers/Sakura.AspNetCore.Mvc.TagHelpers.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.TagHelpers/Sakura.AspNetCore.Mvc.TagHelpers.csproj
@@ -5,11 +5,12 @@
     <AssemblyTitle>ASP.NET Core MVC Extensions Library</AssemblyTitle>
     <VersionPrefix>1.3.3</VersionPrefix>
     <Authors>Iris Sakura</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Sakura.AspNetCore.Mvc.TagHelpers</AssemblyName>
     <PackageId>Sakura.AspNetCore.Mvc.TagHelpers</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;MVC;MVCCore;TagHelper;Enum;Flags;OptionLabel;Select;Option</PackageTags>
-    <PackageReleaseNotes>EnumSelectTagHelper now supports data annotation localization.</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -21,16 +22,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
 </Project>

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.TempDataExtensions/Sakura.AspNetCore.Mvc.TempDataExtensions.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.Mvc.TempDataExtensions/Sakura.AspNetCore.Mvc.TempDataExtensions.csproj
@@ -5,11 +5,12 @@
     <AssemblyTitle>ASP.NET Core TempData Extension Library</AssemblyTitle>
     <VersionPrefix>1.0.1</VersionPrefix>
     <Authors>Iris Sakura</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Sakura.AspNetCore.Mvc.TempDataExtensions</AssemblyName>
     <PackageId>Sakura.AspNetCore.Mvc.TempDataExtensions</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;MVC;MVCCore;TempData;ITempDataProvider</PackageTags>
-    <PackageReleaseNotes>VS 2017 Update</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -20,16 +21,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
 </Project>

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.PagedList.Abstractions/Sakura.AspNetCore.PagedList.Abstractions.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.PagedList.Abstractions/Sakura.AspNetCore.PagedList.Abstractions.csproj
@@ -4,11 +4,12 @@
     <Description>ASP.NET Core PagedList abstraction layer defines the IPagedList and IDynamicPagedList interface and useful extension methods for ASP.NET Core targeted projects. This project does not contains the implementation for creating paged list from a certain data source.</Description>
     <AssemblyTitle>ASP.NET Core PagedList Core Abstraction Layer</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Sakura.AspNetCore.PagedList.Abstractions</AssemblyName>
     <PackageId>Sakura.AspNetCore.PagedList.Abstractions</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;Page;Paging</PackageTags>
-    <PackageReleaseNotes>Update IPagedList&lt;T&gt; interface to solve ambiguous property slot.</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.PagedList.Async/Sakura.AspNetCore.PagedList.Async.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.PagedList.Async/Sakura.AspNetCore.PagedList.Async.csproj
@@ -3,11 +3,12 @@
   <PropertyGroup>
     <Description>This package provides extension method to create PagedList using EntityFramework async method.</Description>
     <AssemblyTitle>ASP.NET Core PagedList Async Extension Library</AssemblyTitle>
-    <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Sakura.AspNetCore.PagedList.Async</AssemblyName>
     <PackageId>Sakura.AspNetCore.PagedList.Async</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;Page;Paging;Cache;Caching</PackageTags>
-    <PackageReleaseNotes>VS 2017 Update</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -23,16 +24,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
 </Project>

--- a/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.PagedList/Sakura.AspNetCore.PagedList.csproj
+++ b/Sakura.AspNetCore.Extensions/Sakura.AspNetCore.PagedList/Sakura.AspNetCore.PagedList.csproj
@@ -4,11 +4,12 @@
     <Description>ASP.NET Core PagedList core library provides data paging functionality for ASP.NET Core targeted projects.</Description>
     <AssemblyTitle>ASP.NET Core PagedList Core Library</AssemblyTitle>
     <VersionPrefix>2.0.1</VersionPrefix>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Sakura.AspNetCore.PagedList</AssemblyName>
     <PackageId>Sakura.AspNetCore.PagedList</PackageId>
     <PackageTags>ASP.NET;ASP.NETCore;Page;Paging;Cache;Caching</PackageTags>
-    <PackageReleaseNotes>Update dependency</PackageReleaseNotes>
+    <PackageReleaseNotes>Update to .NET Core 2.0</PackageReleaseNotes>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <PackageProjectUrl>https://github.com/sgjsakura/AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sgjsakura/AspNetCore/blob/master/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
Pretty new to Github in general, but as the title says:
I've migrated all projects except 'Sakura.AspNetCore.Authentication.ExternalCookie' to Core 2.0.
Said project has some breaking changes for Core 2.0 for which I couldn't find a quick solution.